### PR TITLE
Use regex library and do barcode disambiguation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         version='0.2.0',
         description='Package for estimating UMI counts in Transcript Tag Counting data.',
         packages=find_packages(),
-        install_requires=['click', 'pysam>=0.8.3', 'pandas'],
+        install_requires=['click', 'pysam>=0.8.3', 'pandas', 'regex'],
         ext_modules=[ext],
         setup_requires=['cython'],
         entry_points = {

--- a/umis/umis.py
+++ b/umis/umis.py
@@ -71,8 +71,8 @@ def fastqtransform(transform, fastq1, fastq2, separate_cb, demuxed_cb, dual_inde
                           read2_regex=read2_regex, paired=fastq2)
     p = multiprocessing.Pool(cores)
 
-    chunks = tz.partition(10000, itertools.izip(fastq_file1, fastq_file2))
-    bigchunks = tz.partition(cores, chunks)
+    chunks = tz.partition_all(10000, itertools.izip(fastq_file1, fastq_file2))
+    bigchunks = tz.partition_all(cores, chunks)
     for bigchunk in bigchunks:
         for chunk in p.map(transform, list(bigchunk)):
             for read1_dict in chunk:

--- a/umis/umis.py
+++ b/umis/umis.py
@@ -2,7 +2,7 @@
 
 import itertools
 import collections
-import re
+import regex as re
 import json
 import gzip
 import sys

--- a/umis/umis.py
+++ b/umis/umis.py
@@ -30,14 +30,19 @@ def stream_fastq(file_handler):
 @click.argument('transform', required=True)
 @click.argument('fastq1', required=True)
 @click.argument('fastq2', default=None, required=False)
+@click.option('--separate_cb', is_flag=True, help="Keep dual index barcodes separate.")
 @click.option('--demuxed_cb', default=None)
 @click.option('--dual_index', is_flag=True)
 # @profile
-def fastqtransform(transform, fastq1, fastq2, demuxed_cb, dual_index):
-    ''' Transform input reads to the tagcounts compatible read layout using regular expressions
-    as defined in a transform file. Outputs new format to stdout.
+def fastqtransform(transform, fastq1, fastq2, separate_cb, demuxed_cb, dual_index):
+    ''' Transform input reads to the tagcounts compatible read layout using
+    regular expressions as defined in a transform file. Outputs new format to
+    stdout.
     '''
-    read_template = '{name}:CELL_{CB}:UMI_{MB}\n{seq}\n+\n{qual}\n'
+    if dual_index and separate_cb:
+        read_template = '{name}:CELL_{CB1}_{CB2}:UMI_{MB}\n{seq}\n+\n{qual}\n'
+    else:
+        read_template = '{name}:CELL_{CB}:UMI_{MB}\n{seq}\n+\n{qual}\n'
 
     transform = json.load(open(transform))
     read1_regex = re.compile(transform['read1'])
@@ -80,7 +85,8 @@ def fastqtransform(transform, fastq1, fastq2, demuxed_cb, dual_index):
         read1_dict.update(read2_dict)
 
         if dual_index:
-            read1_dict['CB'] = read1_dict['CB1'] + read1_dict['CB2']
+            if not separate_cb:
+                read1_dict['CB'] = read1_dict['CB1'] + read1_dict['CB2']
 
         if demuxed_cb:
             read1_dict['CB'] = demuxed_cb


### PR DESCRIPTION
Hi Valentine,

This pull request has two things, you can reject either one or both.

The first is to use the regex library instead of the re library. This allows for syntax to allow mismatches in a regex, so for example:

```
{
    "read1": "(?P<name>[^\\s]+)\\n(?P<CB1>\\w{8,11})(GAGTGATTGCTTGTGACGCCTT){e<=3}(?P<CB2>\\w{8})(?P<MB>\\w{6})(.*)\\n+(.*)\\n(.*)\\n",
    "read2": "(@.*)\\n(?P<seq>.*)\\n\\+(.*)\\n(?P<qual>.*)\\n"
}
```

The `{e<=3}` syntax allows for 3 or less errors.

The second change is to do barcode disambiguation. I abstracted out the writing to either write to barcode files or to stdout depending on if the option is set or not.
