### PR TITLE
Allow tagcount to take BAM files as well as SAM files.

### DIFF
--- a/umis/umis.py
+++ b/umis/umis.py
@@ -165,7 +165,8 @@ def tagcount(sam, out, genemap, output_evidence_table, positional, minevidence,
 
     evidence = collections.defaultdict(int)
 
-    sam_file = AlignmentFile(sam, mode='r')
+    sam_mode = 'r' if sam.endswith(".sam") else 'rb'
+    sam_file = AlignmentFile(sam, mode=sam_mode)
     track = sam_file.fetch(until_eof=True)
     count = 0
     kept = 0


### PR DESCRIPTION
Does what it says on the box. Sorry to be a spammy pull requester.

I was also going to implement a flag for tagcount to output transcript compatibility counts, which might be useful downstream (for example http://biorxiv.org/content/early/2016/01/15/036863).
