### PR TITLE
Add barcode mismatch correction.

### DIFF
--- a/umis/barcodes.py
+++ b/umis/barcodes.py
@@ -1,0 +1,107 @@
+import regex as re
+import itertools
+from collections import defaultdict
+
+def exact_barcode_filter(chunk, bc1, bc2):
+    parser_re = re.compile('(.*):CELL_(?P<CB>.*):UMI_(.*)\\n(.*)\\n\\+\\n(.*)\\n')
+    kept = []
+    for read in chunk:
+        match = parser_re.search(read).groupdict()
+        cb1 = match['CB']
+        if bc2:
+            cb1, cb2 = cb1.split("-")
+        if cb1 not in bc1:
+            continue
+        if bc2 and cb2 not in bc2:
+            continue
+        kept.append(read)
+    return kept
+
+def correcting_barcode_filter(chunk, bc1hash, bc2hash):
+    parser_re = re.compile('(.*):CELL_(?P<CB>.*):UMI_(.*)\\n(.*)\\n\\+\\n(.*)\\n')
+    kept = []
+    for read in chunk:
+        match = parser_re.search(read).groupdict()
+        cb1 = match['CB']
+        if bc2hash:
+            cb1, cb2 = cb1.split("-")
+        bc1corrected = bc1hash[cb1]
+        if not bc1corrected:
+            continue
+        if bc2hash:
+            bc2corrected = bc2hash[cb2]
+            if not bc2corrected:
+                continue
+            correctbc = bc1corrected + "-" + bc2corrected
+        else:
+            correctbc = bc1corrected
+        if correctbc == match['CB']:
+            kept.append(read)
+        else:
+            read.replace("CELL_" + match['CB'], "CELL_" + correctbc)
+            kept.append(read)
+    return kept
+
+class MutationHash(object):
+
+    def __init__(self, strings, nedit):
+        self.hash = mutationhash(strings, nedit)
+
+    def __getitem__(self, barcode):
+        """
+        look up a barcode, returning the most commonly seen barcode
+        """
+        result = self.hash[barcode]
+        if len(result) != 1:
+            return None
+        else:
+            return list(result)[0]
+
+def mutationhash(strings, nedit):
+    """
+    produce a hash with each key a nedit distance substitution for a set of
+    strings. values of the hash is the set of strings the substitution could
+    have come from
+    """
+    maxlen = max([len(string) for string in strings])
+    indexes = generate_idx(maxlen, nedit)
+    muthash = defaultdict(set)
+    for string in strings:
+        muthash[string].update([string])
+        for x in substitution_set(string, indexes):
+            muthash[x].update([string])
+    return muthash
+
+def substitution_set(string, indexes):
+    """
+    for a string, return a set of all possible substitutions
+    """
+    strlen = len(string)
+    return {mutate_string(string, x) for x in indexes if valid_substitution(strlen, x)}
+
+def valid_substitution(strlen, index):
+    """
+    skip performing substitutions that are outside the bounds of the string
+    """
+    values = index[0]
+    return all([strlen > i for i in values])
+
+def generate_idx(maxlen, nedit):
+    """
+    generate all possible nedit edits of a string. each item has the form
+    ((index1, index2), 'A', 'G')  for nedit=2
+    index1 will be replaced by 'A', index2 by 'G'
+
+    this covers all edits < nedit as well since some of the specified
+    substitutions will not change the base
+    """
+    ALPHABET = ["A", "C", "G", "T"]
+    indexlists = []
+    return list(itertools.product(itertools.combinations(range(maxlen), nedit),
+                                  ALPHABET, ALPHABET))
+
+def mutate_string(string, tomutate):
+    strlist = list(string)
+    for i, idx in enumerate(tomutate[0]):
+        strlist[idx] = tomutate[i+1]
+    return "".join(strlist)

--- a/umis/barcodes.py
+++ b/umis/barcodes.py
@@ -94,8 +94,9 @@ def generate_idx(maxlen, nedit):
     """
     ALPHABET = ["A", "C", "G", "T"]
     indexlists = []
+    ALPHABETS = [ALPHABET for x in range(nedit)]
     return list(itertools.product(itertools.combinations(range(maxlen), nedit),
-                                  ALPHABET, ALPHABET))
+                                  *ALPHABETS))
 
 def mutate_string(string, tomutate):
     strlist = list(string)

--- a/umis/barcodes.py
+++ b/umis/barcodes.py
@@ -38,7 +38,7 @@ def correcting_barcode_filter(chunk, bc1hash, bc2hash):
         if correctbc == match['CB']:
             kept.append(read)
         else:
-            read.replace("CELL_" + match['CB'], "CELL_" + correctbc)
+            read = read.replace("CELL_" + match['CB'], "CELL_" + correctbc)
             kept.append(read)
     return kept
 

--- a/umis/barcodes.py
+++ b/umis/barcodes.py
@@ -48,9 +48,6 @@ class MutationHash(object):
         self.hash = mutationhash(strings, nedit)
 
     def __getitem__(self, barcode):
-        """
-        look up a barcode, returning the most commonly seen barcode
-        """
         result = self.hash[barcode]
         if len(result) != 1:
             return None

--- a/umis/umis.py
+++ b/umis/umis.py
@@ -376,21 +376,6 @@ def umi_histogram(fastq):
     for bc, count in counter.most_common():
         sys.stdout.write('{}\t{}\n'.format(bc, count))
 
-def cb_filterer(chunk, bc1, bc2):
-    parser_re = re.compile('(.*):CELL_(?P<CB>.*):UMI_(.*)\\n(.*)\\n\\+\\n(.*)\\n')
-    kept = []
-    for read in chunk:
-        match = parser_re.search(read).groupdict()
-        cb1 = match['CB']
-        if bc2:
-            cb1, cb2 = cb1.split("-")
-        if cb1 not in bc1:
-            continue
-        if bc2 and cb2 not in bc2:
-            continue
-        kept.append(read)
-    return kept
-
 def get_cb_depth_set(cb_histogram, cb_cutoff):
     ''' Returns a set of barcodes with a minimum number of reads
     '''

--- a/umis/umis.py
+++ b/umis/umis.py
@@ -321,7 +321,7 @@ def tagcount(sam, out, genemap, output_evidence_table, positional, minevidence,
     buf = StringIO()
     for key in evidence:
         line = '{},{}\n'.format(key, evidence[key])
-        buf.write(line)
+        buf.write(unicode(line), "utf-8")
 
     buf.seek(0)
     evidence_table = pd.read_csv(buf)


### PR DESCRIPTION
Hi Valentine,

This works by making a huge hash table of all possible substitutions of barcodes up front and uses that to correct barcodes with that many substitutions. It is expensive to make the table but once it is made, its quick. It adds about 2x to the processing time on my test dataset. I tried some other implementations of mismatch correction but they were slower and more complicated so I went with this one. 
