### PR TITLE
fastqtransform: avoid always requiring MB

### DIFF
--- a/umis/umis.py
+++ b/umis/umis.py
@@ -291,7 +291,7 @@ def _infer_transform_options(transform):
     CB = False
     dual_index = False
     SB = False
-    MB = True
+    MB = False
     for rx in transform.values():
         if not rx:
             continue


### PR DESCRIPTION
I'm using fastqtransform to get duplex on reads from the 5' end of
R1/R2. These get translated to CELL_CB1-CB2 without a MB UMI. This fix
avoids always requiring MB in the regex.