### PR TITLE
Support dual UMI indexes

### DIFF
--- a/umis/umis.py
+++ b/umis/umis.py
@@ -283,8 +283,12 @@ def fastqtransform(transform, fastq1, fastq2, fastq3, fastq4, keep_fastq_tags,
                                 len(read2_dict['seq']) < min_length)
 
                     if not tooshort:
-                        fastq1out_fh.write(read_template.format(**read1_dict))
-                        fastq2out_fh.write(read_template.format(**read2_dict))
+                        if is_python3():
+                            fastq1out_fh.write(read_template.format(**read1_dict).encode())
+                            fastq2out_fh.write(read_template.format(**read2_dict).encode())
+                        else:
+                            fastq1out_fh.write(read_template.format(**read1_dict))
+                            fastq2out_fh.write(read_template.format(**read2_dict))
             else:
                 for read1_dict in chunk:
                     if options.dual_index and options.CB:
@@ -307,7 +311,10 @@ def fastqtransform(transform, fastq1, fastq2, fastq3, fastq4, keep_fastq_tags,
                     read1_dict = _extract_readnum(read1_dict)
                     if len(read1_dict['seq']) >= min_length:
                         if fastq1out_fh:
-                            fastq1out_fh.write(read_template.format(**read1_dict))
+                            if is_python3():
+                                fastq1out_fh.write(read_template.format(**read1_dict).encode())
+                            else:
+                                fastq1out_fh.write(read_template.format(**read1_dict))
                         else:
                             sys.stdout.write(read_template.format(**read1_dict))
 

--- a/umis/umis.py
+++ b/umis/umis.py
@@ -102,7 +102,7 @@ def write_fastq(filename):
     """
     if filename:
         if filename.endswith('gz'):
-            filename_fh = gzip.open(filename, mode='wb')
+            filename_fh = gzip.open(filename, mode='wt')
         else:
             filename_fh = open(filename, mode='w')
     else:
@@ -283,12 +283,8 @@ def fastqtransform(transform, fastq1, fastq2, fastq3, fastq4, keep_fastq_tags,
                                 len(read2_dict['seq']) < min_length)
 
                     if not tooshort:
-                        if is_python3():
-                            fastq1out_fh.write(read_template.format(**read1_dict).encode())
-                            fastq2out_fh.write(read_template.format(**read2_dict).encode())
-                        else:
-                            fastq1out_fh.write(read_template.format(**read1_dict))
-                            fastq2out_fh.write(read_template.format(**read2_dict))
+                        fastq1out_fh.write(read_template.format(**read1_dict))
+                        fastq2out_fh.write(read_template.format(**read2_dict))
             else:
                 for read1_dict in chunk:
                     if options.dual_index and options.CB:
@@ -311,10 +307,7 @@ def fastqtransform(transform, fastq1, fastq2, fastq3, fastq4, keep_fastq_tags,
                     read1_dict = _extract_readnum(read1_dict)
                     if len(read1_dict['seq']) >= min_length:
                         if fastq1out_fh:
-                            if is_python3():
-                                fastq1out_fh.write(read_template.format(**read1_dict).encode())
-                            else:
-                                fastq1out_fh.write(read_template.format(**read1_dict))
+                            fastq1out_fh.write(read_template.format(**read1_dict))
                         else:
                             sys.stdout.write(read_template.format(**read1_dict))
 


### PR DESCRIPTION
Using `MB1` and `MB2` it is now possible to handle dual UMIs like
cellular barcodes.

Fixes issue #65.

There's also a small Python3 compatibility fix, or `umis` would error trying to save to gzipped FASTQ files.