### PR TITLE
Fix bamtag with dual UMIs

### DIFF
--- a/umis/umis.py
+++ b/umis/umis.py
@@ -157,7 +157,8 @@ def construct_transformed_regex(annotations):
     if "cellular" in annotations:
         re_string += ":CELL_(?P<CB>.*)"
     if "molecular" in annotations:
-        re_string += ":UMI_(?P<MB>\w*)"
+        # Detect dual UMIs spaced with either _ or - if present
+        re_string += ':UMI_(?P<MB>\w[-_\w]*)'
     if "sample" in annotations:
         re_string += ":SAMPLE_(?P<SB>\w*)"
     if re_string == ".*":


### PR DESCRIPTION
bamtag uses a regex to identify the UMIs, but said regex stops at word
boundary, therefore missing the second part of the barcode (dual UMIs
are in the form UMI_XXXX_YYYY or UMI_XXXX-YYYY).

This commit adds an optional check for words past `-` or `_`.